### PR TITLE
feat: Run the protocol locally to test it

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Package",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${fileDirname}"
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+run:
+	go run main.go
+
 test:
 	go test -timeout 5s ./...
 

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ func main() {
 		manager              = prototari.MakeUDPManager(config)
 		sigchan              = make(chan os.Signal, 1)
 		privIP, broadIP, err = prototari.GetPrivateIPAndBroadcastAddr()
+		peersCh              = manager.PeersCh()
 	)
 
 	if err != nil {
@@ -25,14 +26,29 @@ func main() {
 
 	manager.Start()
 	defer func() {
-		manager.Stop()
+		log.Println("Defer function: calling manger.Close()...")
+		manager.Close()
 		log.Println("Done. Bye!")
 	}()
 
 	log.Println("Pelotari protocol starting... Press CTRL+C to exit.")
 
 	signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
-	<-sigchan
+
+loop:
+	for {
+		select {
+		case <-sigchan:
+			// User pressed CTRL+C. Exit!
+			log.Println("Closing connections...")
+			break loop
+		case peers := <-peersCh:
+			log.Println("----- [Peers] -----")
+			for _, peer := range peers {
+				log.Printf("\t> %s\n", peer.Address())
+			}
+		}
+	}
 
 	log.Println("Closing connections...")
 }

--- a/main.go
+++ b/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/angelsolaorbaiceta/prototari/prototari"
+)
+
+func main() {
+	var (
+		config               = prototari.MakeDefaultConfig()
+		manager              = prototari.MakeUDPManager(config)
+		sigchan              = make(chan os.Signal, 1)
+		privIP, broadIP, err = prototari.GetPrivateIPAndBroadcastAddr()
+	)
+
+	if err != nil {
+		panic(err)
+	}
+	log.Println("========================= [Pelotari] =========================")
+	log.Printf("Private IP: %s, Broadcast IP: %s\n", privIP, broadIP)
+
+	manager.Start()
+	defer func() {
+		manager.Stop()
+		log.Println("Done. Bye!")
+	}()
+
+	log.Println("Pelotari protocol starting... Press CTRL+C to exit.")
+
+	signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
+	<-sigchan
+
+	log.Println("Closing connections...")
+}

--- a/prototari/comms_manager.go
+++ b/prototari/comms_manager.go
@@ -150,7 +150,6 @@ func (m *CommsManager) startRespondingToBroadcasts() {
 		default:
 			n, addr, err := m.broadcaster.Read(buff)
 			if err != nil {
-				// log.Printf("Error reading broadcast: %v", err)
 				continue
 			}
 
@@ -184,7 +183,6 @@ func (m *CommsManager) startListeningToUnicast() {
 		default:
 			n, addr, err := m.unicaster.Read(buff)
 			if err != nil {
-				// log.Printf("Error reading unicast: %v", err)
 				continue
 			}
 

--- a/prototari/comms_manager.go
+++ b/prototari/comms_manager.go
@@ -162,7 +162,10 @@ func (m *CommsManager) startRespondingToBroadcasts() {
 				peerAddr := *addr
 				peerAddr.Port = UnicastPort
 
-				m.unicaster.Write([]byte(responseMessage), &peerAddr)
+				_, err := m.unicaster.Write([]byte(responseMessage), &peerAddr)
+				if err != nil {
+					log.Printf("Couldn't send response to %s: %s\n", peerAddr.IP, err)
+				}
 			}
 		}
 	}

--- a/prototari/comms_manager.go
+++ b/prototari/comms_manager.go
@@ -27,6 +27,22 @@ type CommsManager struct {
 	wg        sync.WaitGroup
 }
 
+func MakeUDPManager(config Config) *CommsManager {
+	var (
+		broadcaster = UDPBroadcastConn{}
+		unicaster   = UDPUnicastConn{}
+	)
+
+	broadcaster.Connect()
+	unicaster.Connect()
+
+	return MakeManager(
+		&broadcaster,
+		&unicaster,
+		config,
+	)
+}
+
 func MakeManager(
 	broadcaster BroadcastConn,
 	unicaster UnicastConn,
@@ -113,7 +129,7 @@ func (m *CommsManager) startRespondingToBroadcasts() {
 
 	var (
 		buff = make([]byte, 128)
-		myIp = m.broadcaster.LocalAddr().IP
+		myIP = m.broadcaster.LocalAddr().IP
 	)
 
 	for {
@@ -128,7 +144,7 @@ func (m *CommsManager) startRespondingToBroadcasts() {
 			}
 
 			// Ignore our own broadcast messages
-			if myIp.Equal(addr.IP) {
+			if myIP.Equal(addr.IP) {
 				continue
 			}
 

--- a/prototari/config.go
+++ b/prototari/config.go
@@ -9,7 +9,7 @@ const (
 	BroadcastPort = 21451
 	UnicastPort   = 21450
 
-	connReadTimeout time.Duration = 250 * time.Millisecond
+	connReadTimeout time.Duration = 200 * time.Millisecond
 )
 
 // Config is the set of parameters that modify the protocol's behaviour.

--- a/prototari/connections.go
+++ b/prototari/connections.go
@@ -13,6 +13,7 @@ type BroadcastConn interface {
 	// Write sends a payload as a broadcast UDP message to the local network.
 	// It returns the number of sent bytes.
 	Write(b []byte) (int, error)
+
 	// Read receives broadcast messages from the local network.
 	// The number of read bytes and the UDP address of the sender are returned.
 	Read(b []byte) (int, *net.UDPAddr, error)

--- a/prototari/connections.go
+++ b/prototari/connections.go
@@ -17,6 +17,9 @@ type BroadcastConn interface {
 	// Read receives broadcast messages from the local network.
 	// The number of read bytes and the UDP address of the sender are returned.
 	Read(b []byte) (int, *net.UDPAddr, error)
+
+	// Close closes the broadcast connections.
+	Close()
 }
 
 // UnicastConn is the connection used to send and receive unicast messages
@@ -32,4 +35,7 @@ type UnicastConn interface {
 	// Read receives unicast messages from peers on the local network.
 	// The number of read bytes and the UDP address of the sender are returned.
 	Read(b []byte) (int, *net.UDPAddr, error)
+
+	// Close closes the unicast connections.
+	Close()
 }

--- a/prototari/ips.go
+++ b/prototari/ips.go
@@ -1,0 +1,62 @@
+package prototari
+
+import (
+	"errors"
+	"fmt"
+	"net"
+)
+
+// GetPrivateIPAndBroadcastAddr returns this computer's private IP (typically
+// a 192.168.0.0/16 IP) and the broadcast IP in the private network.
+// It iterates through the system network interfaces and stops when the first
+// private IP is found. Thus if a computer is connected to the home wifi router
+// using Ethernet and WIFI, one of the two will be chosen.
+func GetPrivateIPAndBroadcastAddr() (net.IP, net.IP, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get network interfaces: %w", err)
+	}
+
+	for _, iface := range interfaces {
+		// Skip interfaces that are down, and loopback
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			// Skip this interface: we can't get its addresses
+			continue
+		}
+
+		for _, addr := range addrs {
+			ipNet, ok := addr.(*net.IPNet)
+			if ok && ipNet.IP.To4() != nil && ipNet.IP.IsPrivate() {
+				broadcastAddr := calculateBroadcastAddr(ipNet)
+				return ipNet.IP, broadcastAddr, nil
+			}
+		}
+	}
+
+	return nil, nil, errors.New("no private IPv4 address found")
+}
+
+func calculateBroadcastAddr(ipNet *net.IPNet) net.IP {
+	var (
+		ip   = ipNet.IP.To4()
+		mask = ipNet.Mask
+	)
+
+	if ip == nil {
+		// Not an IPv4
+		return nil
+	}
+
+	broadcast := make(net.IP, len(ip))
+	for i := 0; i < len(ip); i++ {
+		// Bitwise OR with the inverse of the mask
+		broadcast[i] = ip[i] | ^mask[i]
+	}
+
+	return broadcast
+}

--- a/prototari/test_doubles.go
+++ b/prototari/test_doubles.go
@@ -68,6 +68,11 @@ func (fb *fakeBroadcastConn) Read(b []byte) (int, *net.UDPAddr, error) {
 	return n, message.From, nil
 }
 
+func (fu *fakeBroadcastConn) Close() {
+	// Nothing to do.
+	// Channels should be manually closed in the tests.
+}
+
 type fakeUnicastConn struct {
 	writeChan chan<- fakeMsgRecord
 	readChan  <-chan fakeMsgRecord
@@ -113,4 +118,9 @@ func (fu *fakeUnicastConn) Read(b []byte) (int, *net.UDPAddr, error) {
 	}
 	n := copy(b, message.Payload)
 	return n, message.From, nil
+}
+
+func (fu *fakeUnicastConn) Close() {
+	// Nothing to do.
+	// Channels should be manually closed in the tests.
 }

--- a/prototari/udp.go
+++ b/prototari/udp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"time"
 )
 
 // UDPBroadcastConn is an implementation of the BroadcastConn interface that uses
@@ -43,7 +44,6 @@ func (conn *UDPBroadcastConn) Connect() {
 		// If a UDP address can't be dialed, the protocol can't work.
 		log.Fatal(err)
 	}
-	fmt.Println("---> UDPBroadcastConn.locadAddresses() was called.")
 	conn.broadcastAddr = broadcastAddr
 
 	sendConn, err := net.DialUDP("udp", nil, conn.broadcastAddr)
@@ -78,6 +78,7 @@ func (conn UDPBroadcastConn) Write(b []byte) (int, error) {
 }
 
 func (conn UDPBroadcastConn) Read(b []byte) (int, *net.UDPAddr, error) {
+	conn.readConn.SetReadDeadline(time.Now().Add(connReadTimeout))
 	return conn.readConn.ReadFromUDP(b)
 }
 
@@ -151,6 +152,7 @@ func (conn UDPUnicastConn) Write(b []byte, to *net.UDPAddr) (int, error) {
 }
 
 func (conn UDPUnicastConn) Read(b []byte) (int, *net.UDPAddr, error) {
+	conn.readConn.SetReadDeadline(time.Now().Add(connReadTimeout))
 	return conn.readConn.ReadFromUDP(b)
 }
 

--- a/prototari/udp.go
+++ b/prototari/udp.go
@@ -143,9 +143,9 @@ func (conn UDPUnicastConn) LocalAddr() *net.UDPAddr {
 }
 
 func (conn UDPUnicastConn) Write(b []byte, to *net.UDPAddr) (int, error) {
-	sendConn, err := net.DialUDP("upd", nil, to)
+	sendConn, err := net.DialUDP("udp", nil, to)
 	if err != nil {
-		return 0, nil
+		return 0, err
 	}
 
 	return sendConn.Write(b)

--- a/prototari/udp.go
+++ b/prototari/udp.go
@@ -1,0 +1,168 @@
+package prototari
+
+import (
+	"fmt"
+	"log"
+	"net"
+)
+
+// UDPBroadcastConn is an implementation of the BroadcastConn interface that uses
+// the UDP connection-less protocol to send and receive messages.
+type UDPBroadcastConn struct {
+	localAddr     *net.UDPAddr
+	broadcastAddr *net.UDPAddr
+
+	isConnected bool
+
+	sendConn *net.UDPConn
+	readConn *net.UDPConn
+}
+
+func (conn *UDPBroadcastConn) Connect() {
+	if conn.isConnected {
+		return
+	}
+
+	privIP, broadIP, err := GetPrivateIPAndBroadcastAddr()
+	if err != nil {
+		// Not much we can do here.
+		// A network protocol can't work without a network.
+		log.Fatal(err)
+	}
+
+	conn.localAddr = &net.UDPAddr{
+		IP:   privIP,
+		Port: BroadcastPort,
+	}
+	broadcastAddr, err := net.ResolveUDPAddr(
+		"udp",
+		fmt.Sprintf("%s:%d", broadIP, BroadcastPort),
+	)
+	if err != nil {
+		// Not much we can do here.
+		// If a UDP address can't be dialed, the protocol can't work.
+		log.Fatal(err)
+	}
+	fmt.Println("---> UDPBroadcastConn.locadAddresses() was called.")
+	conn.broadcastAddr = broadcastAddr
+
+	sendConn, err := net.DialUDP("udp", nil, conn.broadcastAddr)
+	if err != nil {
+		// Not much we can do here.
+		// If a UDP address can't be dialed, the protocol can't work.
+		log.Fatal(err)
+	}
+	conn.sendConn = sendConn
+
+	readAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf(":%d", BroadcastPort))
+	if err != nil {
+		log.Fatal(err)
+	}
+	readUdpConn, err := net.ListenUDP("udp", readAddr)
+	if err != nil {
+		// Not much we can do here.
+		// If a UDP address can't be dialed, the protocol can't work.
+		panic(err)
+	}
+	conn.readConn = readUdpConn
+
+	conn.isConnected = true
+}
+
+func (conn UDPBroadcastConn) LocalAddr() *net.UDPAddr {
+	return conn.localAddr
+}
+
+func (conn UDPBroadcastConn) Write(b []byte) (int, error) {
+	return conn.sendConn.Write(b)
+}
+
+func (conn UDPBroadcastConn) Read(b []byte) (int, *net.UDPAddr, error) {
+	return conn.readConn.ReadFromUDP(b)
+}
+
+func (conn *UDPBroadcastConn) Close() {
+	if !conn.isConnected {
+		return
+	}
+
+	conn.sendConn.Close()
+	conn.readConn.Close()
+
+	conn.sendConn = nil
+	conn.readConn = nil
+	conn.localAddr = nil
+	conn.broadcastAddr = nil
+
+	conn.isConnected = false
+}
+
+// UDPUnicastConn is an implementation of the UnicastConn interface that uses
+// the UDP connection-less protocol to send and receive messages.
+type UDPUnicastConn struct {
+	localAddr   *net.UDPAddr
+	isConnected bool
+	readConn    *net.UDPConn
+}
+
+func (conn *UDPUnicastConn) Connect() {
+	if conn.isConnected {
+		return
+	}
+
+	privIP, _, err := GetPrivateIPAndBroadcastAddr()
+	if err != nil {
+		// Not much we can do here.
+		// A network protocol can't work without a network.
+		log.Fatal(err)
+	}
+
+	conn.localAddr = &net.UDPAddr{
+		IP:   privIP,
+		Port: BroadcastPort,
+	}
+
+	readAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf(":%d", UnicastPort))
+	if err != nil {
+		log.Fatal(err)
+	}
+	readUdpConn, err := net.ListenUDP("udp", readAddr)
+	if err != nil {
+		// Not much we can do here.
+		// If a UDP address can't be dialed, the protocol can't work.
+		panic(err)
+	}
+	conn.readConn = readUdpConn
+
+	conn.isConnected = true
+}
+
+func (conn UDPUnicastConn) LocalAddr() *net.UDPAddr {
+	return conn.localAddr
+}
+
+func (conn UDPUnicastConn) Write(b []byte, to *net.UDPAddr) (int, error) {
+	sendConn, err := net.DialUDP("upd", nil, to)
+	if err != nil {
+		return 0, nil
+	}
+
+	return sendConn.Write(b)
+}
+
+func (conn UDPUnicastConn) Read(b []byte) (int, *net.UDPAddr, error) {
+	return conn.readConn.ReadFromUDP(b)
+}
+
+func (conn *UDPUnicastConn) Close() {
+	if !conn.isConnected {
+		return
+	}
+
+	conn.readConn.Close()
+
+	conn.readConn = nil
+	conn.localAddr = nil
+
+	conn.isConnected = false
+}


### PR DESCRIPTION
# Summary

This PR implements the `BroadcastConn` and `UnicastConn` interfaces using the UDP protocol.
These implementations, called `UDPBroadcastConn` and `UDPUnicastConn` are used in a `main.go` program to test the connectivity between computers in the same network.

> [!NOTE]
> This repository is meant to serve as a Go library for other programs who wish to use the protocol.
> Including a `main.go` program is done just for testing purposes, and to serve as an example of how to use the communications manager.